### PR TITLE
Filter out YT music entires

### DIFF
--- a/src/util/videoUtil.js
+++ b/src/util/videoUtil.js
@@ -36,6 +36,10 @@ function filterShorts(videos) {
     return videos.filter(video => !video.title.includes("#shorts") && !video.title.includes("#Shorts"));
 }
 
+function filterYouTubeMusic(videos) {
+    return videos.filter(video => video.header === "YouTube");
+}
+
 export function filterNonVideos(videos) {
     let result = filterDeletedVideos(videos);
     return filterPollsAndAds(result);
@@ -56,6 +60,7 @@ export function mostWatchedChannels(json, month, year, shortFilter) {
     if (shortFilter) {
         filteredByTime = filterShorts(filteredByTime);
     }
+    filteredByTime = filterYouTubeMusic(filteredByTime);
     let filtered = filterDeletedVideos(filteredByTime);
     let deletedRatio = `${filteredByTime.length - filtered.length} out of ${filteredByTime.length}`;
     let channels = filtered.map(video => video.subtitles[0].name);
@@ -82,6 +87,7 @@ export function mostWatchedVideos(json, month, year, shortFilter) {
     if (shortFilter) {
         filteredByTime = filterShorts(filteredByTime);
     }
+    filteredByTime = filterYouTubeMusic(filteredByTime);
     let filtered = filterDeletedVideos(filteredByTime);
     let deletedRatio = `${filteredByTime.length - filtered.length} out of ${filteredByTime.length}`;
     let videos = filtered.map(video => video.titleUrl);


### PR DESCRIPTION
The watch history export contains both YouTube and YouTube Music entries, differentiated by the `header` property being either `YouTube` or `YouTube Music` (which changes with the language).

This change will completely filter out YT music entries, but you can add a checkbox like the shorts filter too. It's up to you what you want to have on the UI.